### PR TITLE
Protect raw tex code for Pandoc 3.x

### DIFF
--- a/vignettes/MorphoTools2_tutorial.Rmd
+++ b/vignettes/MorphoTools2_tutorial.Rmd
@@ -1,5 +1,8 @@
 ---
-title: \vspace{+2.0cm} MorphoTools2 version 1.0.1.0 tutorial \vspace{+2.0cm}
+title: |
+  ```{=tex}
+  \vspace{+2.0cm} MorphoTools2 version 1.0.1.0 tutorial \vspace{+2.0cm}
+  ```
 author: |
   | developed by **Marek Šlenker**\footnotemark[2] \footnotemark[3] \footnotemark[1] \vspace*{0.5pc}
   | with contributions from **Petr Koutecký**\footnotemark[4] &nbsp;and **Karol Marhold**\footnotemark[2] \footnotemark[3] \vspace*{0.7pc}


### PR DESCRIPTION
Without protecting the LaTeX commands, Pandoc 3.x will convert the title to

```
\title{\vspace{+2.0cm}\\
MorphoTools2 version 1.0.1.0 tutorial \vspace{+2.0cm}}
```

which will lead to this LaTeX error (https://www.stats.ox.ac.uk/pub/bdr/M1mac/MorphoTools2.out):

```
! LaTeX Error: There's no line here to end.
```

That means `\\` cannot be used to break the line after `\vspace{}` when there is no other content before `\vspace{}`.

Currently the error is reflected on CRAN's M1mac machine only (because it uses Pandoc 3.0.1): https://cran.r-project.org/web/checks/check_results_MorphoTools2.html but it is reproducible on any platform with Pandoc 3.0.1 installed.